### PR TITLE
if page loads in BG, listen for any storage change

### DIFF
--- a/newTab.js
+++ b/newTab.js
@@ -287,8 +287,6 @@ function drawWindow(id, title, x, y, w, h, z) {
 			browser.bookmarks.create({
 				parentId: formData.get('origin'),
 				title: formData.get('folderName')
-			}).then(function() {
-				location.reload();
 			});
 		});
 	});
@@ -384,15 +382,11 @@ document.addEventListener('dragend', function() {
 	) {
 		chrome.bookmarks.get(dragon_target, function(e) { // check if we're already in the destination
 			if (e[0].parentId !== drop_target) {
-				chrome.bookmarks.move(dragon_target, {parentId: drop_target}).then(function() {
-					location.reload();
-				}); // moving between zones
+				chrome.bookmarks.move(dragon_target, {parentId: drop_target}); // moving between zones
 			}
 		});
 	} else if (dragon_target && delete_drop_target) { // dropping in vortex
-		browser.bookmarks.remove(dragon_target).then(function() {
-			location.reload();
-		});
+		browser.bookmarks.remove(dragon_target);
 	}
 
 	location.reload();
@@ -435,9 +429,7 @@ document.addEventListener('keydown', function (e) {
 				{
 					title: formData.get('folderName')
 				}
-			).then(function() {
-				location.reload();
-			});
+			);
 		});
 	}
 
@@ -445,3 +437,26 @@ document.addEventListener('keydown', function (e) {
 		location.reload();
 	}
 });
+
+// page is loaded in background, listen for storage changes
+if (document.visibilityState === 'hidden') {
+	chrome.storage.onChanged.addListener(reload);
+}
+
+// page is displayed or hidden
+document.addEventListener("visibilitychange", function() {
+	if (document.visibilityState === 'hidden') {
+		chrome.storage.onChanged.addListener(reload);
+	} else if (document.visibilityState === 'visible') {
+		chrome.storage.onChanged.removeListener(reload);
+	}
+})
+
+function reload() {
+	location.reload();
+}
+
+// listen for bookmark changes
+browser.bookmarks.onChanged.addListener(reload);
+browser.bookmarks.onMoved.addListener(reload);
+browser.bookmarks.onCreated.addListener(reload);


### PR DESCRIPTION
to anticipate an eventual **preload** feature from the WebExtension API.
if page loads _hidden_, it's probably a preload. Reload if the storage changes.
if visibility changes to _visible_, don't listen to storage change.

not to be merged until https://bugzilla.mozilla.org/show_bug.cgi?id=1619373